### PR TITLE
add submission server for 2023 conference

### DIFF
--- a/conferences/conference-2023/call-for-presentations.md
+++ b/conferences/conference-2023/call-for-presentations.md
@@ -13,7 +13,7 @@
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/committees">Committees</a>
   —
-  <a href="#" target="_blank">Submissions</a>
+  <a href="https://easychair.org/conferences/?conf=fheorg2023" target="_blank">Submissions</a>
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/program">Program</a>
   —

--- a/conferences/conference-2023/committees.md
+++ b/conferences/conference-2023/committees.md
@@ -13,7 +13,7 @@
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/committees"><b>Committees</b></a>
   —
-  <a href="#" target="_blank">Submissions</a>
+  <a href="https://easychair.org/conferences/?conf=fheorg2023" target="_blank">Submissions</a>
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/program">Program</a>
   —

--- a/conferences/conference-2023/contact.md
+++ b/conferences/conference-2023/contact.md
@@ -13,7 +13,7 @@
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/committees">Committees</a>
   —
-  <a href="#" target="_blank">Submissions</a>
+  <a href="https://easychair.org/conferences/?conf=fheorg2023" target="_blank">Submissions</a>
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/program">Program</a>
   —

--- a/conferences/conference-2023/home.md
+++ b/conferences/conference-2023/home.md
@@ -13,7 +13,7 @@
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/committees">Committees</a>
   —
-  <a href="#" target="_blank">Submissions</a>
+  <a href="https://easychair.org/conferences/?conf=fheorg2023" target="_blank">Submissions</a>
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/program">Program</a>
   —

--- a/conferences/conference-2023/program.md
+++ b/conferences/conference-2023/program.md
@@ -13,7 +13,7 @@
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/committees">Committees</a>
   —
-  <a href="#" target="_blank">Submissions</a>
+  <a href="https://easychair.org/conferences/?conf=fheorg2023" target="_blank">Submissions</a>
   —
   <a href="https://fhe-org.github.io/conferences/conference-2023/program"><b>Program</b></a>
   —

--- a/conferences/conference-2023/submissions.md
+++ b/conferences/conference-2023/submissions.md
@@ -1,1 +1,27 @@
+<!-- Main header navigation -->
+<p align="center">
+  <img width="200" src="https://user-images.githubusercontent.com/5758427/180978488-db825482-5a58-4c7c-9589-c494a6f0be04.png"><br/>
+  <a href="https://fhe-org.github.io">Home</a> | <a href="https://fhe-org.github.io/fhe-resources">Resources</a> | <a href="https://fhe-org.github.io/fhe-use-cases">Use cases</a> | <a href="https://fhe-org.github.io/conferences/conference-2023/home"><b>Conference 2023</b></a> | <a href="https://discord.fhe.org">Discord</a> | <a href="https://fheorg.substack.com">Newsletter</a> 
+</p>
+<hr/>
+<!-- /Main header navigation -->
+<!-- Header conference 2023 links -->
+<p align="center">
+  <a href="https://fhe-org.github.io/conferences/conference-2023/home">Home</a>
+  —
+  <a href="https://fhe-org.github.io/conferences/conference-2023/call-for-presentations">Call for presentations</a>
+  —
+  <a href="https://fhe-org.github.io/conferences/conference-2023/committees">Committees</a>
+  —
+  <a href="https://easychair.org/conferences/?conf=fheorg2023" target="_blank">Submissions</a>
+  —
+  <a href="https://fhe-org.github.io/conferences/conference-2023/program"><b>Program</b></a>
+  —
+  <a href="https://fhe-org.github.io/conferences/conference-2023/contact">Contact</a>
+</p>
+<hr/>
+<!-- /Header conference 2023 links -->
+
+# FHE.org conference 2023
+Submissions are done via easychair here: https://easychair.org/conferences/?conf=fheorg2023
 


### PR DESCRIPTION
@zaccherinij I wasn't sure if we wanted the "submissions" link in the header to direct to https://easychair.org/conferences/?conf=fheorg2023 or https://fhe-org.github.io/conferences/conference-2023/submissions, so I just copied what we did last year and linked directly to easychair.