### PR TITLE
Carrotcypher patch 1

### DIFF
--- a/advisory-board/README.md
+++ b/advisory-board/README.md
@@ -1,0 +1,46 @@
+<!-- Main header navigation -->
+<p align="center">
+  <img width="200" src="https://user-images.githubusercontent.com/5758427/180978488-db825482-5a58-4c7c-9589-c494a6f0be04.png"><br/>
+  <a href="https://fhe-org.github.io"><b>Home</b></a> | <a href="https://fhe-org.github.io/resources">Resources</a> | <a href="https://fhe-org.github.io/conferences/conference-2024/">Conference 2024</a> | <a href="https://fhe-org.github.io/community">Join the community</a>
+</p>
+<hr/>
+<!-- /Main header navigation -->
+
+
+<p align="center">
+Save the date! <a href="https://fhe-org.github.io/conferences/conference-2024/">FHE.org Toronto 2024</a> is officially announced and <a href="https://rwc.iacr.org/2024/colocated.php">co-locating with Real World Crypto 2024</a> on March 23rd-24th 2024.
+</p>
+<hr/>
+
+
+
+
+### FHE.org Advisory Board
+
+The FHE.org advisory board is designed to bring together key players in FHE to foster collaboration and organization of FHE.org events. The core responsibility of the board is to provide oversight and direction to the FHE.org initiative as a whole.
+
+The desired outcome of the advisory board program is to:
+
+- Ensure conferences have the highest quality talks, presentations, posters, attendees, marketing channels, and sponsorship opportunities
+- Promote a fair playing ground for all companies
+- Maximize adoption of FHE
+
+The advisory board meets once per quarter, online, to discuss these issues and any other outstanding points-of-order. The advisory board can be contacted via: advisory_board@fhe.org. 
+
+#### Members
+- Shruthi Gorantala, Google 
+- Pascal Paillier, Zama [Chair]
+- Damien Stehle, CryptoLab
+- Ingrid Verbauwhede, KU Leuven
+
+
+
+
+
+
+<!--- Footer --->
+<hr/>
+💙 This website is a resource provided and contributed by the FHE.org community and is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>. We welcome any contributions to this website! Read the <a href="https://fhe-org.github.io/contrib">contribution guidelines</a> first and simply open a PR on the <a href="https://github.com/fhe-org/fhe-org">Github repo</a> to add your resources.
+
+
+

--- a/advisory_board/README.md
+++ b/advisory_board/README.md
@@ -1,46 +1,8 @@
-<!-- Main header navigation -->
-<p align="center">
-  <img width="200" src="https://user-images.githubusercontent.com/5758427/180978488-db825482-5a58-4c7c-9589-c494a6f0be04.png"><br/>
-  <a href="https://fhe-org.github.io"><b>Home</b></a> | <a href="https://fhe-org.github.io/resources">Resources</a> | <a href="https://fhe-org.github.io/conferences/conference-2024/">Conference 2024</a> | <a href="https://fhe-org.github.io/community">Join the community</a>
-</p>
-<hr/>
-<!-- /Main header navigation -->
+<meta http-equiv="Refresh" content="0; url='https://fhe.org/advisory-board'" />
+<script>
+  window.location.href = "https://fhe.org/conferences/advisory-board";
+</script>
 
-
-<p align="center">
-Save the date! <a href="https://fhe-org.github.io/conferences/conference-2024/">FHE.org Toronto 2024</a> is officially announced and <a href="https://rwc.iacr.org/2024/colocated.php">co-locating with Real World Crypto 2024</a> on March 23rd-24th 2024.
-</p>
-<hr/>
-
-
-
-
-### FHE.org Advisory Board
-
-The FHE.org advisory board is designed to bring together key players in FHE to foster collaboration and organization of FHE.org events. The core responsibility of the board is to provide oversight and direction to the FHE.org initiative as a whole.
-
-The desired outcome of the advisory board program is to:
-
-- Ensure conferences have the highest quality talks, presentations, posters, attendees, marketing channels, and sponsorship opportunities
-- Promote a fair playing ground for all companies
-- Maximize adoption of FHE
-
-The advisory board meets once per quarter, online, to discuss these issues and any other outstanding points-of-order. The advisory board can be contacted via: advisory_board@fhe.org. 
-
-#### Members
-- Shruthi Gorantala, Google 
-- Pascal Paillier, Zama [Chair]
-- Damien Stehle, CryptoLab
-- Ingrid Verbauwhede, KU Leuven
-
-
-
-
-
-
-<!--- Footer --->
-<hr/>
-💙 This website is a resource provided and contributed by the FHE.org community and is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>. We welcome any contributions to this website! Read the <a href="https://fhe-org.github.io/contrib">contribution guidelines</a> first and simply open a PR on the <a href="https://github.com/fhe-org/fhe-org">Github repo</a> to add your resources.
-
+Redirecting to https://fhe.org/advisory-board.
 
 


### PR DESCRIPTION
Fixed naming of advisory_board to advisory-board and added redirect.