### PR TITLE
Add conference talk on BASALISC hardware accelerator.

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -82,6 +82,7 @@
 
 ## Hardware
 
+- [BASALISC: Integrated Hardware Acceleration for BGV, CKKS, and BFV FHE](https://www.youtube.com/watch?v=-12xxt5BqUU&list=PLnbmMskCVh1fZy00EZQnFSezctvwYmlRM&index=8) by **David Archer, Robin Geelen, and Michiel Van Beirendonck** on **March 24, 2024**
 - [An Optical Hardware Accelerator for FHE](https://fhe.org/meetups/027-An_Optical_Hardware_Accelerator_for_FHE) by **Joseph Wilson** on **June 15, 2023**
 - [Hardware accelerator for FHEW](https://fhe.org/meetups/024-Hardware_accelerator_for_FHEW) by **Jonas Bertels** on **May 25, 2023**
 - [Medha: Microcoded Hardware Accelerator for computing on Encrypted Data](https://fhe.org/meetups/020-Medha_Microcoded_Hardware_Accelerator_for_computing_on_Encrypted_Data) by **Ahmet Can Mert and Aikata** on **Feb 16, 2023**


### PR DESCRIPTION
This talk was presented at the FHE.org conference.

I had previously suggested adding the BASALISC paper in this PR (https://github.com/FHE-org/fhe-org.github.io/pull/138), but it was suggested that a talk resource would be preferable.