### PR TITLE
Apply consistent date format in README

### DIFF
--- a/conferences/conference-2027/README.md
+++ b/conferences/conference-2027/README.md
@@ -42,8 +42,8 @@ For updates, make sure to subscribe to the [FHE.org newsletter](https://fheorg.s
 - **Conference date:** April 4, 2027
 
 ## Latest updates
-- **2025.01.07:** Conference website online
-- **2025.08.07:** Program Chairs announced (David Archer and Rachel Player)
+- **2025.07.01:** Conference website online
+- **2025.07.08:** Program Chairs announced (David Archer and Rachel Player)
 
 ## Sponsors
 *Interested in showing your support for FHE research and development through your company? Consider sponsoring this or future conferences just as our [2026 sponsors](https://fhe.org/conferences/conference-2026/sponsor) have. Reach out to us at contact@fhe.org.*


### PR DESCRIPTION
I would highly recommend using `ISO 8061` for the dates listed in the README.md. Judging by the pages for previous conferences (2025, 2026), it becomes clear that `ISO 8061` has been used properly in the past. However, as currently written, one of the bullet points on conference-2027 is listed as `2026-08-07`, which suggests that something was announced in August of this year! Surely a mistake.

If I got something wrong here, just let me know; I am admittedly feeling tired today.